### PR TITLE
Update FormsBuilder.java

### DIFF
--- a/src/main/java/com/rebuild/server/configuration/portals/FormsBuilder.java
+++ b/src/main/java/com/rebuild/server/configuration/portals/FormsBuilder.java
@@ -228,7 +228,7 @@ public class FormsBuilder extends FormsManager {
 
 			boolean triggersReadonly = autoReadonlyByTriggers.contains(fieldName);
 			// 不可更新字段
-			if ((data != null && !fieldMeta.isUpdatable()) || triggersReadonly) {
+			if (!fieldMeta.isUpdatable() || triggersReadonly) {
 				el.put("readonly", true);
 			}
 


### PR DESCRIPTION
新建流程表单时data始终为空，会导致readonly属性无法应用