### PR TITLE
Fix 3.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.rebuild</groupId>
     <artifactId>rebuild</artifactId>
-    <version>3.4.4</version>
+    <version>3.4.5</version>
     <name>rebuild</name>
     <description>Building your business-systems freely!</description>
     <!-- UNCOMMENT USE TOMCAT -->

--- a/src/main/java/com/rebuild/core/Application.java
+++ b/src/main/java/com/rebuild/core/Application.java
@@ -73,11 +73,11 @@ public class Application implements ApplicationListener<ApplicationStartedEvent>
     /**
      * Rebuild Version
      */
-    public static final String VER = "3.4.4";
+    public static final String VER = "3.4.5";
     /**
      * Rebuild Build [MAJOR]{1}[MINOR]{2}[PATCH]{2}[BUILD]{2}
      */
-    public static final int BUILD = 3040409;
+    public static final int BUILD = 3040510;
 
     static {
         // Driver for DB

--- a/src/main/java/com/rebuild/core/configuration/ConfigBean.java
+++ b/src/main/java/com/rebuild/core/configuration/ConfigBean.java
@@ -33,16 +33,22 @@ public class ConfigBean implements Serializable, Cloneable, JSONable {
 
     /**
      * @param name
-     * @param value Remove if null
+     * @param value
      * @return
      */
     public ConfigBean set(String name, Object value) {
         Assert.notNull(name, "[name] cannot be null");
-        if (value == null) {
-            data.remove(name);
-        } else {
-            data.put(name, value);
-        }
+        data.put(name, value);
+        return this;
+    }
+
+    /**
+     * @param name
+     * @return
+     */
+    public ConfigBean remove(String name) {
+        Assert.notNull(name, "[name] cannot be null");
+        data.remove(name);
         return this;
     }
 

--- a/src/main/java/com/rebuild/core/configuration/general/AutoFillinManager.java
+++ b/src/main/java/com/rebuild/core/configuration/general/AutoFillinManager.java
@@ -176,7 +176,7 @@ public class AutoFillinManager implements ConfigManager {
             }
 
             ConfigBean clone = e.clone().set("value", value);
-            clone.set("source", null);
+            clone.remove("source");
             fillin.add(clone.toJSON());
         }
         return fillin;

--- a/src/main/java/com/rebuild/core/configuration/general/DataListManager.java
+++ b/src/main/java/com/rebuild/core/configuration/general/DataListManager.java
@@ -215,7 +215,7 @@ public class DataListManager extends BaseLayoutManager {
         JSONArray charts = (JSONArray) e.getJSON("config");
         ChartManager.instance.richingCharts(charts, null);
         return e.set("config", charts)
-                .set("shareTo", null);
+                .remove("shareTo");
     }
 
     /**

--- a/src/main/java/com/rebuild/core/configuration/general/FormsBuilder.java
+++ b/src/main/java/com/rebuild/core/configuration/general/FormsBuilder.java
@@ -266,7 +266,7 @@ public class FormsBuilder extends FormsManager {
                 .getExtraAttr(EasyEntityConfigProps.DISABLED_VIEW_EDITABLE);
         model.set("onViewEditable", !BooleanUtils.toBoolean(disabledViewEditable));
 
-        model.set("id", null);  // Clean form's ID of config
+        model.remove("id");  // Clean form's ID of config
         return model.toJSON();
     }
 

--- a/src/main/java/com/rebuild/core/configuration/general/FormsManager.java
+++ b/src/main/java/com/rebuild/core/configuration/general/FormsManager.java
@@ -36,8 +36,7 @@ public class FormsManager extends BaseLayoutManager {
                     .set("elements", JSONUtils.EMPTY_ARRAY);
         } else {
             entry.set("elements", entry.getJSON("config"))
-                    .set("config", null)
-                    .set("shareTo", null);
+                    .remove("config").remove("shareTo");
         }
         return entry.set("entity", entity);
     }

--- a/src/main/java/com/rebuild/core/configuration/general/MultiSelectManager.java
+++ b/src/main/java/com/rebuild/core/configuration/general/MultiSelectManager.java
@@ -37,7 +37,7 @@ public class MultiSelectManager extends PickListManager {
     public JSONArray getSelectList(Field field) {
         ConfigBean[] entries = getPickListRaw(field, false);
         for (ConfigBean e : entries) {
-            e.set("hide", null).set("id", null);
+            e.remove("hide").remove("id");
         }
         return JSONUtils.toJSONArray(entries);
     }

--- a/src/main/java/com/rebuild/core/configuration/general/PickListManager.java
+++ b/src/main/java/com/rebuild/core/configuration/general/PickListManager.java
@@ -39,8 +39,7 @@ public class PickListManager implements ConfigManager {
     public JSONArray getPickList(Field field) {
         ConfigBean[] entries = getPickListRaw(field, false);
         for (ConfigBean e : entries) {
-            e.set("hide", null);
-            e.set("mask", null);
+            e.remove("hide").remove("mask");
         }
         return JSONUtils.toJSONArray(entries);
     }

--- a/src/main/java/com/rebuild/core/service/trigger/impl/FieldWriteback.java
+++ b/src/main/java/com/rebuild/core/service/trigger/impl/FieldWriteback.java
@@ -470,6 +470,8 @@ public class FieldWriteback extends FieldAggregation {
                                 targetRecord.setNull(targetField);
                             }
                         }
+                    } else if (clearFields) {
+                        targetRecord.setNull(targetField);
                     }
                 }
             }


### PR DESCRIPTION
1. [修复] [字段更新](https://getrebuild.com/docs/admin/trigger/fieldwriteback) 使用公式时，“源字段为空时置空目标字段”选项无效
2. [修复] 企业微信应用可见范围非全员时导致 [同步组织架构](https://getrebuild.com/docs/admin/integration-wxwork#%E5%90%8C%E6%AD%A5%E7%BB%84%E7%BB%87%E6%9E%B6%E6%9E%84) 失败
3. [修复] [表单回填](https://getrebuild.com/docs/admin/entity/field-reference#%E8%A1%A8%E5%8D%95%E5%9B%9E%E5%A1%AB) 强制回填空值时无效