### PR TITLE
feat(图表): 添加图表复制功能

### DIFF
--- a/src/main/java/com/rebuild/web/dashboard/ChartDesignController.java
+++ b/src/main/java/com/rebuild/web/dashboard/ChartDesignController.java
@@ -232,4 +232,25 @@ public class ChartDesignController extends EntityController {
 
         return RespBody.ok(record.getPrimary());
     }
+    
+    @RequestMapping("chart-copy")
+    public RespBody chartCopy(@IdParam ID chartId, HttpServletRequest request) {
+        final ID user = getRequestUser(request);
+        
+        // 获取原图表信息
+        Object[] chart = Application.createQueryNoFilter(
+                "select belongEntity,title,config,chartType from ChartConfig where chartId = ?")
+                .setParameter(1, chartId)
+                .unique();
+        
+        // 创建新记录
+        Record record = EntityHelper.forNew(EntityHelper.ChartConfig, user);
+        record.setString("belongEntity", (String) chart[0]);
+        record.setString("title", chart[1] + " " + Language.L("(副本)"));
+        record.setString("config", (String) chart[2]);
+        record.setString("chartType", (String) chart[3]);
+        
+        record = Application.getBean(ChartConfigService.class).createOrUpdate(record);
+        return RespBody.ok(record.getPrimary());
+    }
 }

--- a/src/main/resources/web/assets/js/charts/charts.js
+++ b/src/main/resources/web/assets/js/charts/charts.js
@@ -148,11 +148,20 @@ class BaseChart extends React.Component {
         $.post(`${rb.baseUrl}/dashboard/chart-copy?id=${that.props.id}`, (res) => {
           if (res.error_code === 0) {
             RbHighbar.success($L('图表已复制'))
-            setTimeout(() => location.reload(), 1500)
-          } else {
+            if (window.add_widget) {
+              window.add_widget({
+                chart: res.data,
+                w: 4,
+                h: 4,
+                isManageable: true
+              })
+              window.save_dashboard()
+              setTimeout(() => location.reload(), 1000)
+            } else {
             RbHighbar.error(res.error_msg || $L('操作失败'))
+            }
+            this.disabled(false)
           }
-          this.disabled(false)
         })
       }
     })

--- a/src/main/resources/web/assets/js/charts/charts.js
+++ b/src/main/resources/web/assets/js/charts/charts.js
@@ -39,6 +39,11 @@ class BaseChart extends React.Component {
               {$L('编辑')}
             </a>
           )}
+          {this.props.isManageable && !this.props.builtin && (
+            <a className="dropdown-item J_chart-copy" onClick={() => this.copy()}>
+              {$L('复制')}
+            </a>
+          )}
           {this.props.editable && (
             <a className="dropdown-item" onClick={() => this.remove()}>
               {$L('移除')}
@@ -132,6 +137,24 @@ class BaseChart extends React.Component {
         else if (window.chart_remove) window.chart_remove($(that._$box))
         this.hide()
       },
+    })
+  }
+  
+  copy() {
+    const that = this
+    RbAlert.create($L('确认复制此图表？'), {
+      confirm: function() {
+        this.disabled(true)
+        $.post(`${rb.baseUrl}/dashboard/chart-copy?id=${that.props.id}`, (res) => {
+          if (res.error_code === 0) {
+            RbHighbar.success($L('图表已复制'))
+            setTimeout(() => location.reload(), 1500)
+          } else {
+            RbHighbar.error(res.error_msg || $L('操作失败'))
+          }
+          this.disabled(false)
+        })
+      }
     })
   }
 


### PR DESCRIPTION
在图表操作菜单中增加复制选项，支持快速创建图表副本。
后端新增 chart-copy 接口处理复制逻辑，复制时保留原图表配置并自动添加"(副本)"后缀。